### PR TITLE
Style/remove separators from sub headings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -66,7 +66,15 @@ const withMDX = createMDX({
     rehypePlugins: [
       rehypeHighlight,
       rehypeSlug,
-      [rehypeAutoLinkHeadings, { behavior: "wrap" }],
+      [
+        rehypeAutoLinkHeadings,
+        {
+          behavior: "wrap",
+          properties: {
+            isHeading: true,
+          },
+        },
+      ],
     ],
   },
 });

--- a/src/shared/ui/anchor.tsx
+++ b/src/shared/ui/anchor.tsx
@@ -1,5 +1,13 @@
 import React, { ComponentPropsWithoutRef } from "react";
 
-export default function Anchor(props: ComponentPropsWithoutRef<"a">) {
-  return <a {...props} className="hover:underline" />;
+export default function Anchor({
+  isHeading,
+  ...props
+}: ComponentPropsWithoutRef<"a"> & { isHeading?: boolean }) {
+  return (
+    <a
+      {...props}
+      className={`${isHeading ? "hover:underline" : "underline"}`}
+    />
+  );
 }

--- a/src/shared/ui/heading.tsx
+++ b/src/shared/ui/heading.tsx
@@ -1,51 +1,34 @@
 import { ComponentPropsWithoutRef, ReactNode } from "react";
 import { Separator } from "./separator";
 
-function BaseHeading({ children }: { children: ReactNode }) {
-  return (
-    <>
-      {children}
-      <Separator />
-    </>
-  );
-}
-
 export function Heading1(props: ComponentPropsWithoutRef<"h1">) {
   return (
-    <div className="my-10 space-y-7">
-      <BaseHeading>
-        <h1 className="text-4xl font-extrabold text-black" {...props} />
-      </BaseHeading>
+    <div className="my-10">
+      <h1 className="text-7xl font-extrabold text-black" {...props} />
     </div>
   );
 }
 
 export function Heading2(props: ComponentPropsWithoutRef<"h2">) {
   return (
-    <div className="my-7 space-y-5">
-      <BaseHeading>
-        <h2 className="text-3xl font-bold text-black" {...props} />
-      </BaseHeading>
+    <div className="mb-12 mt-24">
+      <h2 className="text-5xl font-bold text-black" {...props} />
     </div>
   );
 }
 
 export function Heading3(props: ComponentPropsWithoutRef<"h3">) {
   return (
-    <div className="my-5 space-y-3">
-      <BaseHeading>
-        <h3 className="text-2xl font-bold text-black" {...props} />
-      </BaseHeading>
+    <div className="mb-8 mt-16">
+      <h3 className="text-3xl font-bold text-black" {...props} />
     </div>
   );
 }
 
 export function Heading4(props: ComponentPropsWithoutRef<"h4">) {
   return (
-    <div className="my-4 space-y-2">
-      <BaseHeading>
-        <h4 className="text-xl font-bold text-black" {...props} />
-      </BaseHeading>
+    <div className="mb-5 mt-11">
+      <h4 className="text-xl font-bold text-black" {...props} />
     </div>
   );
 }

--- a/src/shared/ui/heading.tsx
+++ b/src/shared/ui/heading.tsx
@@ -1,5 +1,4 @@
-import { ComponentPropsWithoutRef, ReactNode } from "react";
-import { Separator } from "./separator";
+import { ComponentPropsWithoutRef } from "react";
 
 export function Heading1(props: ComponentPropsWithoutRef<"h1">) {
   return (


### PR DESCRIPTION
## Description

- [x] Removed `<Separator/>` from every heading since underline styling is already being used
- [x] Conditionally render underline for anchor element. Only apply underline explicitly if it is wrapped by heading element.(`isHeading` props)
- [x] Adjust margin to relate each heading to the content below. `margin-top` is as twice as `margin-bottom`. 